### PR TITLE
Update logo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Cellij Logo](https://github.com/bioFAM/cellij/blob/feature/issue-x/logo/docs/_static/logo2.png)](https://github.com/bioFAM/cellij)
+[![Cellij Logo](https://github.com/bioFAM/cellij/blob/main/docs/_static/logo2.png)](https://github.com/bioFAM/cellij)
 
 # cellij
 


### PR DESCRIPTION
As expected the link to the logo depends on the PR's branch Hence, this hotfix to change it to the master branch.