### PR TITLE
Added earlystopping functionality

### DIFF
--- a/cellij/core/_factormodel.py
+++ b/cellij/core/_factormodel.py
@@ -9,6 +9,7 @@ import pyro
 import torch
 from pyro.infer import SVI
 from pyro.nn import PyroModule
+from cellij.core.utils_training import EarlyStopper
 
 from cellij.core._data import DataContainer
 
@@ -227,9 +228,7 @@ class FactorModel(PyroModule):
                 self.add_data(name=modality_name, data=anndata_object, merge=False)
 
         if merge:
-
             self._data.merge_data(**kwargs)
-
 
     def _add_data(
         self,
@@ -292,9 +291,29 @@ class FactorModel(PyroModule):
         else:
             raise ValueError(f"Level must be 'feature' or 'obs', not {level}")
 
-    def fit(self, likelihood, epochs=1000, learning_rate=0.003, verbose_epochs=100):
+    def fit(
+        self,
+        likelihood,
+        epochs=1000,
+        learning_rate=0.003,
+        verbose_epochs=100,
+        early_stopping=True,
+        patience=500,
+        min_delta=0.1,
+        percentage=True,
+    ):
         # Clear pyro param
         pyro.clear_param_store()
+
+        # If early stopping is set, check if it is a valid value
+        if early_stopping:
+            if min_delta < 0:
+                raise ValueError("min_delta must be positive.")
+            earlystopper = EarlyStopper(
+                patience=patience, min_delta=min_delta, percentage=percentage
+            )
+        else:
+            earlystopper = None
 
         # Check if data is set
         if self._data is None:
@@ -316,10 +335,23 @@ class FactorModel(PyroModule):
         # # Center data
         data = self._model.values - self._model.values.mean(dim=0)
 
+        self.losses = []
         for i in range(epochs + 1):
             loss = svi.step(X=data)
+            self.losses.append(loss)
+
+            if early_stopping:
+                if earlystopper.step(loss):
+                    print(f"Early stopping of training due to convergence at step {i}")
+                    break
 
             if i % verbose_epochs == 0:
-                print(f"Epoch {i:>6}: {loss:>14.2f}")
+                if i > 1:
+                    rel_change = f"{100 - 100*self.losses[i]/self.losses[i - verbose_epochs]:7.2f}%"
+                else:
+                    rel_change = ""
+
+                print(f"Epoch {i:>6}: {loss:>14.2f} \t | {rel_change}")
 
         self._is_trained = True
+        print("Training finished.")

--- a/cellij/core/utils_training.py
+++ b/cellij/core/utils_training.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+
+class EarlyStopper(object):
+    """Class to manage early stopping of model training.
+
+    Adapted from https://gist.github.com/stefanonardo
+    """
+
+    def __init__(self, mode="min", min_delta=0, patience=10, percentage=False):
+        self.mode = mode
+        self.min_delta = min_delta
+        self.patience = patience
+        self.best = None
+        self.num_bad_epochs = 0
+        self.is_better = None
+        self._init_is_better(mode, min_delta, percentage)
+
+        if patience == 0:
+            self.is_better = lambda a, b: True
+            self.step = lambda a: False
+
+    def step(self, metrics):
+        if self.best is None:
+            self.best = metrics
+            return False
+
+        if np.isnan(metrics):
+            return True
+
+        if np.isinf(metrics):
+            self.num_bad_epochs += 1
+        elif self.is_better(metrics, self.best):
+            self.num_bad_epochs = 0
+            self.best = metrics
+        else:
+            self.num_bad_epochs += 1
+
+        if self.num_bad_epochs >= self.patience:
+            return True
+
+        return False
+
+    def _init_is_better(self, mode, min_delta, percentage):
+        if mode not in {"min", "max"}:
+            raise ValueError("mode " + mode + " is unknown!")
+        if not percentage:
+            if mode == "min":
+                self.is_better = lambda a, best: a < best - min_delta
+            if mode == "max":
+                self.is_better = lambda a, best: a > best + min_delta
+        else:
+            if mode == "min":
+                self.is_better = lambda a, best: a < best - (
+                    abs(best) * min_delta / 100
+                )
+            if mode == "max":
+                self.is_better = lambda a, best: a > best + (
+                    abs(best) * min_delta / 100
+                )


### PR DESCRIPTION
Added `EarlyStopper` class which allows to stop training based on relative or absolute difference.
If the training does not improve more than `min_delta` percent (`percentage=True`) or absolute values (`percentage=False`) within `patience` steps, the training is stopped.