### PR TITLE
Removed add_data functionality for MOFA model

### DIFF
--- a/cellij/core/models.py
+++ b/cellij/core/models.py
@@ -1,11 +1,3 @@
-from typing import Optional, Union
-
-import anndata
-import muon
-import numpy
-import pandas
-import torch
-
 from cellij.core._factormodel import FactorModel
 from cellij.core._pyro_models import MOFA_Model
 
@@ -24,23 +16,3 @@ class MOFA(FactorModel):
         kwargs = {**mofa_defaults, **kwargs}
 
         super(MOFA, self).__init__(n_factors=n_factors, **kwargs)
-
-    def add_data(
-        self,
-        data: Union[
-            numpy.ndarray, pandas.DataFrame, torch.Tensor, anndata.AnnData, muon.MuData
-        ],
-        name: Optional[Union[str, None]] = None,
-        **kwargs,
-    ):
-        """Adds data to the model.
-
-        Parameters
-        ----------
-        data : torch.Tensor
-            The data to be added
-        name : str
-            The name of the data
-        """
-
-        super().add_data(data=data, name=name, **kwargs)


### PR DESCRIPTION
@timtreis Was there a particular reason why we needed the `add_data` in the MOFA model class as well? Code runs without it.