### PR TITLE
Speed-up look-up operation

### DIFF
--- a/cellij/core/_data.py
+++ b/cellij/core/_data.py
@@ -142,8 +142,12 @@ class DataContainer:
         self._merged_feature_names = merged_feature_names
 
         for name in self._names:
-            feature_group_obs_names = self._feature_groups[name].obs_names.to_list()
-            feature_group_feature_names = self._feature_groups[name].var_names.to_list()
+            feature_group_obs_names = set(
+                self._feature_groups[name].obs_names.to_list()
+            )
+            feature_group_feature_names = set(
+                self._feature_groups[name].var_names.to_list()
+            )
 
             self._obs_idx[name] = [
                 i


### PR DESCRIPTION
This change speeds-up the lookup if the dataset has a large numer of samples.

For 350'000 samples and 100 features the time is reduced from approx 30mins to 1s. 

```Pyhton
from mudata import MuData
import numpy as np
import pandas as pd

# Create random data
N = 350000
G = 110
X = np.random.rand(N, G)
obs = pd.DataFrame({'cell_type': np.random.choice(['A', 'B', 'C'], N)})
var = pd.DataFrame({'gene': [f'gene_{i}' for i in range(G)]})
adata = sc.AnnData(X=X, obs=obs, var=var)
mdata = MuData({"test": adata})
mdata

model = cellij.FactorModel(n_factors=10)
model.add_data(mdata)
```